### PR TITLE
Look for namespace and other options to configure serializers

### DIFF
--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -51,7 +51,7 @@ module Grape
         end
 
         def build_options_from_endpoint(endpoint)
-          [endpoint.default_serializer_options || {}, endpoint.namespace_options, endpoint.route_options].reduce(:merge)
+          [endpoint.default_serializer_options || {}, endpoint.namespace_options, endpoint.route_options, endpoint.options, endpoint.options.fetch(:route_options)].reduce(:merge)
         end
 
         # array root is the innermost namespace name ('space') if there is one,

--- a/spec/grape-active_model_serializers/formatter_spec.rb
+++ b/spec/grape-active_model_serializers/formatter_spec.rb
@@ -33,7 +33,7 @@ describe Grape::Formatter::ActiveModelSerializers do
   end
 
   describe 'serializer options from namespace' do
-    let(:app){ Class.new(Grape::API) }
+    let(:app) { Class.new(Grape::API) }
 
     before do
       app.format :json


### PR DESCRIPTION
By default not all serializer options are considered (for instance
the :root option, or the :each_serializer option). This potentially
results in an incomplete configuration of the serializers used.

Added 2 specs to test this when used as a single endpoint and when
used within a namespace. At the moment it is fixed by plucking
the correct settings in the .build_options_from_endpoint,
but I could imagine that this is not exactly the right spot.