### PR TITLE
Use env to pass AMS meta around.

### DIFF
--- a/lib/grape-active_model_serializers/endpoint_extension.rb
+++ b/lib/grape-active_model_serializers/endpoint_extension.rb
@@ -36,8 +36,7 @@ module Grape
     end
 
     def render(resources, meta = {})
-      Formatter::ActiveModelSerializers.meta = meta[:meta]
-      Formatter::ActiveModelSerializers.meta_key = meta[:meta_key]
+      Formatter::ActiveModelSerializers.meta = meta
       resources
     end
 

--- a/lib/grape-active_model_serializers/endpoint_extension.rb
+++ b/lib/grape-active_model_serializers/endpoint_extension.rb
@@ -36,7 +36,7 @@ module Grape
     end
 
     def render(resources, meta = {})
-      Formatter::ActiveModelSerializers.meta = meta
+      env['ams_meta'] = meta
       resources
     end
 

--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -28,7 +28,7 @@ module Grape
         def other_options
           options = {}
           meta =  Formatter::ActiveModelSerializers.meta.delete(:meta)
-          meta_key = Formatter::ActiveModelSerializers.meta_key.delete(:meta_key)
+          meta_key = Formatter::ActiveModelSerializers.meta.delete(:meta_key)
           options[:meta_key] = meta_key if meta && meta_key
           options[meta_key || :meta] = meta if meta
           options
@@ -39,15 +39,7 @@ module Grape
         end
 
         def meta=(value)
-          @meta = value ? { meta: value } : nil
-        end
-
-        def meta_key
-          @meta_key || {}
-        end
-
-        def meta_key=(key)
-          @meta_key = key ? { meta_key: key } : nil
+          @meta = value
         end
 
         def build_options_from_endpoint(endpoint)

--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -22,24 +22,17 @@ module Grape
           options[:scope] = endpoint unless options.key?(:scope)
           # ensure we have an root to fallback on
           options[:resource_name] = default_root(endpoint) if resource.respond_to?(:to_ary)
-          serializer.new(resource, options.merge(other_options))
+          serializer.new(resource, options.merge(other_options(env)))
         end
 
-        def other_options
+        def other_options(env)
           options = {}
-          meta =  Formatter::ActiveModelSerializers.meta.delete(:meta)
-          meta_key = Formatter::ActiveModelSerializers.meta.delete(:meta_key)
+          ams_meta = env['ams_meta'] || {}
+          meta =  ams_meta.delete(:meta)
+          meta_key = ams_meta.delete(:meta_key)
           options[:meta_key] = meta_key if meta && meta_key
           options[meta_key || :meta] = meta if meta
           options
-        end
-
-        def meta
-          @meta || {}
-        end
-
-        def meta=(value)
-          @meta = value
         end
 
         def build_options_from_endpoint(endpoint)

--- a/spec/grape-active_model_serializers/endpoint_extension_spec.rb
+++ b/spec/grape-active_model_serializers/endpoint_extension_spec.rb
@@ -20,19 +20,22 @@ describe 'Grape::EndpointExtension' do
   let(:users) { [user, user] }
 
   describe '#render' do
+    before do
+      allow(subject).to receive(:env).and_return({})
+    end
     it { should respond_to(:render) }
     let(:meta_content) { { total: 2 } }
     let(:meta_full) { { meta: meta_content } }
     context 'supplying meta' do
       it 'passes through the Resource and uses given meta settings' do
-        expect(serializer).to receive(:meta=).with(meta_full)
+        allow(subject).to receive(:env).and_return(meta: meta_full)
         expect(subject.render(users, meta_full)).to eq(users)
       end
     end
     context 'supplying meta and key' do
       let(:meta_key) { { meta_key: :custom_key_name } }
       it 'passes through the Resource and uses given meta settings' do
-        expect(serializer).to receive(:meta=).with(meta_full.merge(meta_key))
+        allow(subject).to receive(:env).and_return(meta: meta_full.merge(meta_key))
         expect(subject.render(users, meta_full.merge(meta_key))).to eq(users)
       end
     end

--- a/spec/grape-active_model_serializers/endpoint_extension_spec.rb
+++ b/spec/grape-active_model_serializers/endpoint_extension_spec.rb
@@ -25,15 +25,14 @@ describe 'Grape::EndpointExtension' do
     let(:meta_full) { { meta: meta_content } }
     context 'supplying meta' do
       it 'passes through the Resource and uses given meta settings' do
-        expect(serializer).to receive(:meta=).with(meta_content)
+        expect(serializer).to receive(:meta=).with(meta_full)
         expect(subject.render(users, meta_full)).to eq(users)
       end
     end
     context 'supplying meta and key' do
       let(:meta_key) { { meta_key: :custom_key_name } }
       it 'passes through the Resource and uses given meta settings' do
-        expect(serializer).to receive(:meta=).with(meta_content)
-        expect(serializer).to receive(:meta_key=).with(meta_key[:meta_key])
+        expect(serializer).to receive(:meta=).with(meta_full.merge(meta_key))
         expect(subject.render(users, meta_full.merge(meta_key))).to eq(users)
       end
     end

--- a/spec/grape-active_model_serializers/formatter_spec.rb
+++ b/spec/grape-active_model_serializers/formatter_spec.rb
@@ -5,8 +5,6 @@ describe Grape::Formatter::ActiveModelSerializers do
   subject { Grape::Formatter::ActiveModelSerializers }
   it { should respond_to(:meta) }
   it { should respond_to(:meta=) }
-  it { should respond_to(:meta_key) }
-  it { should respond_to(:meta_key=) }
 
   context '#meta' do
     it 'will silently accept falsy input but return empty Hash' do
@@ -15,20 +13,8 @@ describe Grape::Formatter::ActiveModelSerializers do
     end
 
     it 'will wrap valid input in the meta: {} wrapper' do
-      subject.meta = { total: 2 }
-      expect(subject.meta).to eq(meta: { total: 2 })
-    end
-  end
-
-  context '#meta_key' do
-    it 'will silently accept falsy input but return empty Hash' do
-      subject.meta_key = nil
-      expect(subject.meta_key).to eq({})
-    end
-
-    it 'will wrap valid input in the meta_key: {} wrapper' do
-      subject.meta_key = :custom_key_name
-      expect(subject.meta_key).to eq(meta_key: :custom_key_name)
+      subject.meta = { meta: { total: 2 } }
+      expect(subject.meta).to eq({ meta: { total: 2 } })
     end
   end
 

--- a/spec/grape-active_model_serializers/formatter_spec.rb
+++ b/spec/grape-active_model_serializers/formatter_spec.rb
@@ -3,20 +3,6 @@ require 'grape-active_model_serializers/formatter'
 
 describe Grape::Formatter::ActiveModelSerializers do
   subject { Grape::Formatter::ActiveModelSerializers }
-  it { should respond_to(:meta) }
-  it { should respond_to(:meta=) }
-
-  context '#meta' do
-    it 'will silently accept falsy input but return empty Hash' do
-      subject.meta = nil
-      expect(subject.meta).to eq({})
-    end
-
-    it 'will wrap valid input in the meta: {} wrapper' do
-      subject.meta = { meta: { total: 2 } }
-      expect(subject.meta).to eq({ meta: { total: 2 } })
-    end
-  end
 
   describe '.fetch_serializer' do
     let(:user) { User.new(first_name: 'John') }


### PR DESCRIPTION
I think this is better than passing things through a module class variable, but I am not 100% sure. This avoids theoretical concurrency issues and possibly some GC.