### PR TITLE
Readme update with note about accessing current_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ class PostSerializer < ActiveModel::Serializer
 end
 ```
 
+*Note*: in the [0.9.x stable version of active model serializers](https://github.com/rails-api/active_model_serializers/tree/0-9-stable#customizing-scope), you have to access current user on scope -  so `scope.current_user`.
+
 ### Full Example
 
 ```ruby


### PR DESCRIPTION
Information about accessing `current_user`. Project using:

- active_model_serializers - 0.9.3
- grape 0.13.0
- grape-active_model_serializers 1.3.2